### PR TITLE
♻️ 描画の最適化 (約55%速度改善)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mizu",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mizu",
-      "version": "0.7.2",
+      "version": "0.8.0",
       "license": "ISC",
       "devDependencies": {
         "@babel/core": "^7.22.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mizu",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "`Mizu` is a joke script that simulates water(H2o) generation in JavaScript.",
   "main": "index.js",
   "type": "module",

--- a/tests/Mizu.test.js
+++ b/tests/Mizu.test.js
@@ -16,18 +16,6 @@ describe('MizuSimulatorクラスのテスト', () => {
   let simulator;
 
   beforeEach(() => {
-    const createElement = document.createElement.bind(document);
-    document.createElement = (tagName) => {
-      // imgタグに関しては、context.drawImageに渡すと、
-      // `Image given has not completed loading`
-      // と怒られてしまうので、mockの目印となるような関数だけ生やしておく。
-      // context.drawImageを使わなくてもテストは可能。
-      if (tagName === 'img') {
-        return { isMock: jest.fn() };
-      }
-      return createElement(tagName);
-    };
-
     simulator = new MizuSimulator();
   });
 


### PR DESCRIPTION
Atomごとにcanvasを作成し描画していたが、それをやめて一つのcanvas(ステージ用canvas)に対して描画するように修正。
これにより、Hの数を150, Oの数を250とした場合に以下の差が出た。

**1フレームの描画時間**

- 修正前
  - 約18ms
- 修正後
  - 約8ms

なので、**約55%** 速度が改善したことになる。